### PR TITLE
Build basic scheduler MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Scheduler MVP
+
+A minimal scheduling application demo with week/day/agenda views, event creation, and drag-and-drop rescheduling.
+
+## Running
+Open `index.html` in a modern browser. No build step is required.
+
+## Testing
+Run conflict detection tests with:
+
+```bash
+npm test
+```

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-Hello Git and GitHub

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scheduler MVP</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Scheduler MVP</h1>
+    <nav>
+      <button id="dayViewBtn">Day</button>
+      <button id="weekViewBtn">Week</button>
+      <button id="agendaViewBtn">Agenda</button>
+    </nav>
+  </header>
+
+  <section id="calendar"></section>
+
+  <section id="eventFormSection">
+    <h2>Add Event</h2>
+    <form id="eventForm">
+      <label>Title <input name="title" required /></label>
+      <label>Category
+        <select name="category">
+          <option value="Corporate">Corporate</option>
+          <option value="Association A">Association A</option>
+          <option value="Association B">Association B</option>
+          <option value="Association C">Association C</option>
+          <option value="Personal">Personal</option>
+        </select>
+      </label>
+      <label>Day
+        <select name="day">
+          <option value="0">Monday</option>
+          <option value="1">Tuesday</option>
+          <option value="2">Wednesday</option>
+          <option value="3">Thursday</option>
+          <option value="4">Friday</option>
+          <option value="5">Saturday</option>
+          <option value="6">Sunday</option>
+        </select>
+      </label>
+      <label>Start Hour <input type="number" name="start" min="8" max="19" value="9" /></label>
+      <label>End Hour <input type="number" name="end" min="9" max="20" value="10" /></label>
+      <label>Priority
+        <select name="priority">
+          <option value="High">High</option>
+          <option value="Medium" selected>Medium</option>
+          <option value="Low">Low</option>
+        </select>
+      </label>
+      <label>Recurrence (weeks) <input type="number" name="recur" min="0" max="10" value="0" /></label>
+      <button type="submit">Add</button>
+    </form>
+  </section>
+
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,138 @@
+import { categories, events, addEvent, generateRecurrence, hasConflict } from './scheduler.js';
+
+const calendarEl = document.getElementById('calendar');
+const dayBtn = document.getElementById('dayViewBtn');
+const weekBtn = document.getElementById('weekViewBtn');
+const agendaBtn = document.getElementById('agendaViewBtn');
+const form = document.getElementById('eventForm');
+
+let currentView = 'week';
+let currentDay = 0; // Monday
+
+function render() {
+  if (currentView === 'day') renderDayView(currentDay); 
+  else if (currentView === 'agenda') renderAgendaView();
+  else renderWeekView();
+}
+
+dayBtn.addEventListener('click', () => { currentView = 'day'; currentDay = 0; render(); });
+weekBtn.addEventListener('click', () => { currentView = 'week'; render(); });
+agendaBtn.addEventListener('click', () => { currentView = 'agenda'; render(); });
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = new FormData(form);
+  const event = {
+    title: data.get('title'),
+    category: data.get('category'),
+    color: categories[data.get('category')],
+    day: Number(data.get('day')),
+    start: Number(data.get('start')),
+    end: Number(data.get('end')),
+    priority: data.get('priority')
+  };
+  const recur = Number(data.get('recur'));
+  if (!addEvent(event)) {
+    alert('Conflict detected');
+    return;
+  }
+  if (recur > 0) {
+    const recEvents = generateRecurrence(event, recur);
+    recEvents.forEach(ev => {
+      if (!addEvent(ev)) alert('Conflict in recurrence');
+    });
+  }
+  form.reset();
+  render();
+});
+
+function renderWeekView() {
+  calendarEl.innerHTML = '';
+  const grid = document.createElement('div');
+  grid.className = 'week-grid';
+  for (let d = 0; d < 7; d++) {
+    const col = document.createElement('div');
+    col.className = 'day-column';
+    col.dataset.day = d;
+    for (let h = 8; h < 20; h++) {
+      const slot = document.createElement('div');
+      slot.className = 'hour-slot';
+      slot.dataset.day = d;
+      slot.dataset.hour = h;
+      slot.addEventListener('dragover', e => e.preventDefault());
+      slot.addEventListener('drop', handleDrop);
+      col.appendChild(slot);
+    }
+    grid.appendChild(col);
+  }
+  // render events
+  events.forEach(ev => {
+    const col = grid.children[ev.day];
+    const el = document.createElement('div');
+    el.className = 'event';
+    el.textContent = ev.title;
+    el.style.background = ev.color;
+    el.style.top = (ev.start - 8) * 60 + 'px';
+    el.style.height = (ev.end - ev.start) * 60 + 'px';
+    el.draggable = true;
+    el.dataset.id = ev.id;
+    el.addEventListener('dragstart', handleDragStart);
+    col.appendChild(el);
+  });
+  calendarEl.appendChild(grid);
+}
+
+function renderDayView(day) {
+  const dayEvents = events.filter(e => e.day === day);
+  calendarEl.innerHTML = '<h2>Day View</h2>';
+  const list = document.createElement('ul');
+  dayEvents.sort((a,b)=>a.start-b.start).forEach(ev => {
+    const li = document.createElement('li');
+    li.textContent = `${ev.start}:00 - ${ev.end}:00 ${ev.title}`;
+    li.style.color = ev.color;
+    list.appendChild(li);
+  });
+  calendarEl.appendChild(list);
+}
+
+function renderAgendaView() {
+  calendarEl.innerHTML = '<h2>Agenda</h2>';
+  const list = document.createElement('ul');
+  list.className = 'agenda-list';
+  events.slice().sort((a,b)=>a.day - b.day || a.start - b.start).forEach(ev => {
+    const li = document.createElement('li');
+    li.textContent = `${dayName(ev.day)} ${ev.start}:00 - ${ev.end}:00 ${ev.title}`;
+    li.style.color = ev.color;
+    list.appendChild(li);
+  });
+  calendarEl.appendChild(list);
+}
+
+function dayName(d) {
+  return ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'][d];
+}
+
+let draggedId = null;
+function handleDragStart(e) {
+  draggedId = Number(e.target.dataset.id);
+}
+
+function handleDrop(e) {
+  e.preventDefault();
+  const day = Number(e.currentTarget.dataset.day);
+  const hour = Number(e.currentTarget.dataset.hour);
+  const ev = events.find(ev => ev.id === draggedId);
+  if (!ev) return;
+  const duration = ev.end - ev.start;
+  const newEvent = { ...ev, day, start: hour, end: hour + duration };
+  if (newEvent.end > 20 || hasConflict(newEvent, events)) {
+    alert('Invalid move');
+    return;
+  }
+  ev.day = day;
+  ev.start = hour;
+  ev.end = hour + duration;
+  render();
+}
+
+render();

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -1,0 +1,42 @@
+export const categories = {
+  'Corporate': '#1a237e',
+  'Association A': '#00796b',
+  'Association B': '#6a1b9a',
+  'Association C': '#fb8c00',
+  'Personal': '#757575'
+};
+
+export const events = [];
+let idCounter = 0;
+
+export function addEvent(data) {
+  const event = { id: idCounter++, ...data };
+  if (hasConflict(event, events)) {
+    return false;
+  }
+  events.push(event);
+  return true;
+}
+
+export function generateRecurrence(event, weeks) {
+  const list = [];
+  for (let i = 0; i < weeks; i++) {
+    const copy = { ...event, day: (event.day + i) % 7 };
+    list.push(copy);
+  }
+  return list;
+}
+
+export function hasConflict(event, list) {
+  return list.some(e =>
+    e.id !== event.id &&
+    e.day === event.day &&
+    e.start < event.end &&
+    event.start < e.end
+  );
+}
+
+export function removeEvent(id) {
+  const idx = events.findIndex(e => e.id === id);
+  if (idx >= 0) events.splice(idx, 1);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "scheduler-mvp",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/conflict.test.js"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+header {
+  background: #1a237e;
+  color: white;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+nav button {
+  margin-right: 5px;
+}
+#calendar {
+  margin: 10px;
+}
+.week-grid {
+  display: flex;
+  border: 1px solid #ccc;
+  height: 720px; /* 12 hours * 60px */
+}
+.day-column {
+  flex: 1;
+  border-left: 1px solid #eee;
+  position: relative;
+}
+.day-column:first-child {
+  border-left: none;
+}
+.hour-slot {
+  height: 60px;
+  border-bottom: 1px solid #eee;
+}
+.event {
+  position: absolute;
+  color: white;
+  padding: 2px;
+  cursor: move;
+  border-radius: 4px;
+  font-size: 12px;
+  left: 0;
+  right: 0;
+}
+.agenda-list {
+  list-style: none;
+  padding: 0;
+}
+.agenda-list li {
+  margin: 5px 0;
+}

--- a/test/conflict.test.js
+++ b/test/conflict.test.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import { hasConflict } from '../js/scheduler.js';
+
+const events = [
+  { id: 1, day: 0, start: 9, end: 10 },
+  { id: 2, day: 0, start: 11, end: 12 }
+];
+
+// Overlapping event
+const ev1 = { id: 3, day: 0, start: 9.5, end: 10.5 };
+assert.strictEqual(hasConflict(ev1, events), true, 'Should detect conflict');
+
+// Non-overlapping
+const ev2 = { id: 4, day: 0, start: 10, end: 11 };
+assert.strictEqual(hasConflict(ev2, events), false, 'Should not detect conflict');
+
+console.log('Conflict tests passed');


### PR DESCRIPTION
## Summary
- add minimal web-based calendar with week/day/agenda views
- support event creation with categories, priorities and weekly recurrence
- implement drag-and-drop rescheduling with conflict detection
- include simple conflict detection test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968b1195f8832bb1e8d5cc1260bd9c